### PR TITLE
Adds Config for Highlighted Mould color

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ repositories {
 	mavenCentral()
 }
 
-def runeLiteVersion = '1.8.27'
+def runeLiteVersion = 'latest.release'
 
 dependencies {
 	compileOnly group: 'net.runelite', name:'client', version: runeLiteVersion

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryConfig.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryConfig.java
@@ -5,6 +5,8 @@ import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
 import net.runelite.client.config.ConfigSection;
 
+import java.awt.Color;
+
 @ConfigGroup(EasyGiantsFoundryConfig.GROUP)
 public interface EasyGiantsFoundryConfig extends Config {
     String GROUP = "easygiantsfoundry";
@@ -137,10 +139,22 @@ public interface EasyGiantsFoundryConfig extends Config {
     }
 
     @ConfigItem(
+            keyName = "mouldHighlightColor",
+            name = "Highlighted Mould Color",
+            description = "Highlight color of the mould",
+            position = 3,
+            section = highlightList
+    )
+    default Color mouldHighlightColor() {
+        return new Color(13, 193, 13);
+    }
+
+
+    @ConfigItem(
             keyName = "crucibleHighlight",
             name = "Highlight Crucible",
             description = "Highlight Crucible when it should be filled/poured",
-            position = 3,
+            position = 4,
             section = highlightList
     )
     default boolean highlightCrucible() {
@@ -151,7 +165,7 @@ public interface EasyGiantsFoundryConfig extends Config {
             keyName = "kovacHighlight",
             name = "Highlight Kovac for hand in",
             description = "Highlight Kovac when sword can be handed in",
-            position = 4,
+            position = 5,
             section = highlightList
     )
     default boolean highlightKovac() {

--- a/src/main/java/com/toofifty/easygiantsfoundry/MouldHelper.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/MouldHelper.java
@@ -21,10 +21,11 @@ public class MouldHelper
     static final int SWORD_TYPE_1_VARBIT = 13907; // 4=Broad
     static final int SWORD_TYPE_2_VARBIT = 13908; // 3=Flat
     private static final int DISABLED_TEXT_COLOR = 0x9f9f9f;
-    private static final int GREEN = 0xdc10d;
 
     @Inject
     private Client client;
+    @Inject
+    private EasyGiantsFoundryConfig config;
 
     @Inject
     private ClientThread clientThread;
@@ -52,7 +53,7 @@ public class MouldHelper
             }
         }
         if (bestWidget != null) {
-            bestWidget.setTextColor(GREEN);
+            bestWidget.setTextColor(config.mouldHighlightColor().getRGB());
         }
 
         if (scriptId == DRAW_MOULD_LIST_SCRIPT || scriptId == REDRAW_MOULD_LIST_SCRIPT)


### PR DESCRIPTION
I had trouble noticing the default green. 

- Updates runeliteVersion to `latest.release`, inline with the [example plugin](https://github.com/runelite/example-plugin) repo.
- Adds a config item `mouldHighlightColor`
- Uses `config.mouldHighlightColor` when highlighting the mould.


![image](https://user-images.githubusercontent.com/39996391/191305552-dad1ef9f-c5d9-4d50-96d2-6bdae5f6bac8.png)

I initially started to implement full-widget highlighting but there were a few issues I wasn't confident were elegantly solved. ([highlight-widgets](https://github.com/zmanowar/easy-giantsfoundry/tree/highlight-widget) branch) -- happy to work through full widget highlighting if you prefer! 
<details>
  <summary>Full highlight example</summary>
  
![image](https://user-images.githubusercontent.com/39996391/191311355-aef9b56d-f2be-44ba-9e8b-ad3d3beaa6c9.png) Blue highlight is the bestWidget from the MouldHelper and the other is the normal selected highlight, just for comparison.


  
</details>