### PR TITLE
Smith's Outfit pieces buff

### DIFF
--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
@@ -13,6 +13,8 @@ import net.runelite.api.Client;
 import net.runelite.api.GameObject;
 import net.runelite.api.GameState;
 import net.runelite.api.InventoryID;
+import net.runelite.api.Item;
+import net.runelite.api.ItemContainer;
 import net.runelite.api.Skill;
 import net.runelite.api.events.GameObjectDespawned;
 import net.runelite.api.events.GameObjectSpawned;
@@ -33,6 +35,8 @@ import net.runelite.client.events.ConfigChanged;
 import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
+
+import java.util.Set;
 
 @Slf4j
 @PluginDescriptor(
@@ -56,6 +60,9 @@ public class EasyGiantsFoundryPlugin extends Plugin
 	private static final int PREFORM = 27010;
 
 	private static final int REPUTATION_VARBIT = 3436;
+
+	// 5 total items, includes Smiths gloves (i);
+	private static final Set<Integer> SMITHS_OUTFIT_IDS = Set.of(27023, 27025, 27027, 27029, 27031);
 
 	private Stage oldStage;
 
@@ -243,11 +250,17 @@ public class EasyGiantsFoundryPlugin extends Plugin
 	@Subscribe
 	public void onItemContainerChanged(ItemContainerChanged event)
 	{
-		if (event.getContainerId() == InventoryID.EQUIPMENT.getId()
-			&& event.getItemContainer().count(PREFORM) == 0)
+		if (event.getContainerId() == InventoryID.EQUIPMENT.getId())
 		{
-			state.reset();
-			oldStage = null;
+			if (event.getItemContainer().count(PREFORM) == 0)
+			{
+				state.reset();
+				oldStage = null;
+			}
+			else
+			{
+				updateSmithsOutfitPieces();
+			}
 		}
 	}
 
@@ -380,6 +393,29 @@ public class EasyGiantsFoundryPlugin extends Plugin
 		}
 
 		bonusNotified = true;
+	}
+
+	private void updateSmithsOutfitPieces()
+	{
+		int pieces = 0;
+
+		ItemContainer equipment = client.getItemContainer(InventoryID.EQUIPMENT);
+		if (equipment != null)
+		{
+			for (Item item : equipment.getItems())
+			{
+				if (item != null && isSmithsOutfitPiece(item.getId()))
+				{
+					pieces++;
+				}
+			}
+		}
+		state.setSmithsOutfitPieces(pieces);
+	}
+
+	private boolean isSmithsOutfitPiece(int itemId)
+	{
+		return SMITHS_OUTFIT_IDS.contains(itemId);
 	}
 
 	@Provides

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
@@ -29,6 +29,9 @@ public class EasyGiantsFoundryState
 	@Getter
 	private boolean enabled;
 
+	@Setter
+	private int smithsOutfitPieces;
+
 	private final List<Stage> stages = new ArrayList<>();
 	private double heatRangeRatio = 0;
 
@@ -241,7 +244,9 @@ public class EasyGiantsFoundryState
 		double progressTillNext = progressPerStage - progress % progressPerStage;
 
 		Stage current = getCurrentStage();
-		return (int) Math.ceil(progressTillNext / current.getProgressPerAction());
+		// Each Smith's Outfit piece adds 20% chance to increase action progress by 1, or 100% for all 4 pieces.
+		double smithsOutfitBonus = smithsOutfitPieces == 4 ? 1 : 0.2 * smithsOutfitPieces;
+		return (int) Math.ceil(progressTillNext / (current.getProgressPerAction() + smithsOutfitBonus));
 	}
 
 	public int[] getCurrentHeatRange()


### PR DESCRIPTION
This changes alters the state's action left calculation to consider the number of Smith's Outfit pieces currently being worn by the player, based on the following logic:
Each piece adds 20% chance to add 1 progress (so an expected 0.2 progress), while the entire outfit (4 pieces) has 100% chance.

I've opted to have a member variable on EasyGiantsFoundryState that holds the current number of pieces, and use a check on the Preform being equipped within the itemContainerChange event in EasyGiantsFoundryPlugin to calculate the current number of equipped pieces to avoid unnecessary iterations through the inventory. 

Since the event is triggered on login, no additional cases are needed, and the number is always accurate.

An easy verification this works (if you need one), is that by having all 4 items equipped, the first stage (always being the trip hammer) requires 8 actions instead of the default 9 when 3 or less items are equipped.