### PR TITLE
Heat/Cooling Off-by-1 Bug — Mould/Preform Score Calculation Overlay — Fixed Incorrect Crucible Score Calculation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,6 +6,9 @@ repositories {
 	mavenLocal()
 	maven {
 		url = 'https://repo.runelite.net'
+		content {
+			includeGroupByRegex("net\\.runelite.*")
+		}
 	}
 	mavenCentral()
 }
@@ -24,9 +27,36 @@ dependencies {
 }
 
 group = 'com.toofifty'
-version = '1.0.7'
+version = '1.0.8'
 
-tasks.withType(JavaCompile) {
+tasks.withType(JavaCompile).configureEach {
 	options.encoding = 'UTF-8'
-    options.release.set(11)
+	options.release.set(11)
 }
+
+tasks.register('shadowJar', Jar) {
+	dependsOn configurations.testRuntimeClasspath
+	manifest {
+		attributes('Main-Class': 'com.toofifty.easygiantsfoundry.EasyGiantsFoundryPluginTest', 'Multi-Release': true)
+	}
+
+	duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+	from sourceSets.main.output
+	from sourceSets.test.output
+	from {
+		configurations.testRuntimeClasspath.collect { file ->
+			file.isDirectory() ? file : zipTree(file)
+		}
+	}
+
+	exclude 'META-INF/INDEX.LIST'
+	exclude 'META-INF/*.SF'
+	exclude 'META-INF/*.DSA'
+	exclude 'META-INF/*.RSA'
+	exclude '**/module-info.class'
+
+	group = BasePlugin.BUILD_GROUP
+	archiveClassifier.set('shadow')
+	archiveFileName.set("${rootProject.name}-${project.version}-all.jar")
+}
+

--- a/runelite-plugin.properties
+++ b/runelite-plugin.properties
@@ -2,5 +2,5 @@ displayName=Easy Giant's Foundry
 author=Toofifty
 support=https://github.com/Toofifty/easy-giantsfoundry
 description=Helpful overlays for the Giant's Foundry minigame
-tags=smithing,giant,foundry,giantsfoundry,minigame
+tags=smithing,giant,foundry,giantsfoundry,minigame,ez,easy,smith
 plugins=com.toofifty.easygiantsfoundry.EasyGiantsFoundryPlugin

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryConfig.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryConfig.java
@@ -504,15 +504,4 @@ public interface EasyGiantsFoundryConfig extends Config
 	)
 	String generalSettings = "generalSettings";
 
-	@ConfigItem(
-		keyName = "heatingCoolingMarginOfError",
-		name = "Heating/Cooling Margin of Error",
-		description = "The margin of error for lava/waterfall calculations to compensate for decay and overshooting.",
-		position = 0,
-		section = generalSettings
-	)
-	default int heatingCoolingBuffer()
-	{
-		return 20;
-	}
 }

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
@@ -338,7 +338,7 @@ public class EasyGiantsFoundryPlugin extends Plugin
 		{
 			Widget title = Objects.requireNonNull(mouldParent.getChild(1));
 
-			// not sure why, the ":" character turns into ":      ," when rendered; obmitting it.
+			// not sure why, the ":" character turns into ":      ," when rendered; omitting it.
 			title.setText("Giants' Foundry Mould Setup <col=FFFFFF>(Score " + mouldScore + ")");
 		}
 	}
@@ -369,8 +369,8 @@ public class EasyGiantsFoundryPlugin extends Plugin
 
 				state.heatingCoolingState.onTick();
 			}
-			previousHeat = event.getValue();
 		}
+		previousHeat = event.getValue();
 	}
 
 	@Subscribe

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
@@ -1,6 +1,8 @@
 package com.toofifty.easygiantsfoundry;
 
 import com.google.inject.Provides;
+
+import static com.toofifty.easygiantsfoundry.EasyGiantsFoundryClientIDs.VARBIT_GAME_STAGE;
 import static com.toofifty.easygiantsfoundry.EasyGiantsFoundryClientIDs.VARBIT_HEAT;
 import com.toofifty.easygiantsfoundry.enums.Stage;
 
@@ -27,6 +29,7 @@ import net.runelite.api.events.NpcSpawned;
 import net.runelite.api.events.ScriptPostFired;
 import net.runelite.api.events.StatChanged;
 import net.runelite.api.events.VarbitChanged;
+import net.runelite.api.widgets.Widget;
 import net.runelite.client.Notifier;
 import net.runelite.client.callback.ClientThread;
 import net.runelite.client.config.ConfigManager;
@@ -36,6 +39,7 @@ import net.runelite.client.plugins.Plugin;
 import net.runelite.client.plugins.PluginDescriptor;
 import net.runelite.client.ui.overlay.OverlayManager;
 
+import java.util.Objects;
 import java.util.Set;
 
 @Slf4j
@@ -273,8 +277,12 @@ public class EasyGiantsFoundryPlugin extends Plugin
 		{
 			if (event.getMenuOption().equals("Pour"))
 			{
+				if (client.getVarbitValue(VARBIT_GAME_STAGE) == 1)
+				{
+					state.setLastKnownCrucibleScore((int) state.getCrucibleScore());
+				}
 				// add persistent game message of the alloy value so user can reference later.
-				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "The quality of the alloy poured is " + (int) state.getCrucibleQuality(), null);
+				client.addChatMessage(ChatMessageType.GAMEMESSAGE, "", "The score of the preform is <col=00FFFF>" + ((int) state.getCrucibleScore() + state.getMouldScore()), null);
 			}
 		}
 
@@ -315,6 +323,23 @@ public class EasyGiantsFoundryPlugin extends Plugin
 			|| event.getScriptId() == MouldHelper.RESET_MOULD_SCRIPT)
 		{
 			mouldHelper.selectBest(event.getScriptId());
+			updateMouldScore();
+		}
+	}
+
+	private void updateMouldScore() {
+
+		state.setMouldScore(mouldHelper.getTotalScore());
+
+		// show mould score on Mould UI Title
+		Widget mouldParent = client.getWidget(47054850);
+		Integer mouldScore = state.getMouldScore();
+		if (mouldParent != null && mouldScore != null)
+		{
+			Widget title = Objects.requireNonNull(mouldParent.getChild(1));
+
+			// not sure why, the ":" character turns into ":      ," when rendered; obmitting it.
+			title.setText("Giants' Foundry Mould Setup <col=FFFFFF>(Score " + mouldScore + ")");
 		}
 	}
 

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryPlugin.java
@@ -354,6 +354,14 @@ public class EasyGiantsFoundryPlugin extends Plugin
 			reputation = client.getVarpValue(REPUTATION_VARBIT);
 		}
 
+		// STAGE becomes 0 again after player picks up the preform
+		if (event.getVarbitId() == VARBIT_GAME_STAGE && event.getValue() == 0)
+		{
+			// clear out the current and soon to be previous scores.
+			state.setLastKnownCrucibleScore(-1);
+			state.setMouldScore(-1);
+		}
+
 		// start the heating state-machine when the varbit updates
 		// if heat varbit updated and the user clicked, start the state-machine
 		if (event.getVarbitId() == VARBIT_HEAT && state.heatingCoolingState.getActionName() != null)

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
@@ -40,11 +40,11 @@ public class EasyGiantsFoundryState
 
 	@Setter
 	@Getter
-	private Integer mouldScore;
+	private int mouldScore = -1; // starts -1 because mould score is unknown
 
 	@Setter
 	@Getter
-	private Integer lastKnownCrucibleScore;
+	private int lastKnownCrucibleScore = -1; // will be set when "Pour"ed
 
 	private final List<Stage> stages = new ArrayList<>();
 	private double heatRangeRatio = 0;

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
@@ -9,10 +9,8 @@ import static com.toofifty.easygiantsfoundry.enums.Stage.GRINDSTONE;
 import static com.toofifty.easygiantsfoundry.enums.Stage.POLISHING_WHEEL;
 import static com.toofifty.easygiantsfoundry.enums.Stage.TRIP_HAMMER;
 
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
-import lombok.Value;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 
@@ -39,6 +37,14 @@ public class EasyGiantsFoundryState
 
 	@Setter
 	private int smithsOutfitPieces;
+
+	@Setter
+	@Getter
+	private Integer mouldScore;
+
+	@Setter
+	@Getter
+	private Integer lastKnownCrucibleScore;
 
 	private final List<Stage> stages = new ArrayList<>();
 	private double heatRangeRatio = 0;
@@ -223,7 +229,7 @@ public class EasyGiantsFoundryState
 		return bronze + iron + steel + mithril + adamant + rune;
 	}
 
-	public double getCrucibleQuality()
+	public double getCrucibleScore()
 	{
 		// https://oldschool.runescape.wiki/w/Giants%27_Foundry#Metal_score
 

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryState.java
@@ -8,14 +8,19 @@ import com.toofifty.easygiantsfoundry.enums.Stage;
 import static com.toofifty.easygiantsfoundry.enums.Stage.GRINDSTONE;
 import static com.toofifty.easygiantsfoundry.enums.Stage.POLISHING_WHEEL;
 import static com.toofifty.easygiantsfoundry.enums.Stage.TRIP_HAMMER;
+
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;
+import lombok.Value;
 import net.runelite.api.Client;
 import net.runelite.api.widgets.Widget;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 @Singleton
@@ -220,14 +225,9 @@ public class EasyGiantsFoundryState
 
 	public double getCrucibleQuality()
 	{
-		if (getCrucibleCount() == 0) return 0;
+		// https://oldschool.runescape.wiki/w/Giants%27_Foundry#Metal_score
 
-		int bronze = client.getVarbitValue(VARBIT_BRONZE_COUNT);
-		int iron = client.getVarbitValue(VARBIT_IRON_COUNT);
-		int steel = client.getVarbitValue(VARBIT_STEEL_COUNT);
-		int mithril = client.getVarbitValue(VARBIT_MITHRIL_COUNT);
-		int adamant = client.getVarbitValue(VARBIT_ADAMANT_COUNT);
-		int rune = client.getVarbitValue(VARBIT_RUNE_COUNT);
+		if (getCrucibleCount() == 0) return 0;
 
 		final int BRONZE_VALUE = 1;
 		final int IRON_VALUE = 2;
@@ -236,16 +236,35 @@ public class EasyGiantsFoundryState
 		final int ADAMANT_VALUE = 5;
 		final int RUNE_VALUE = 6;
 
-		final double vB = (10 * BRONZE_VALUE * bronze) / 28.0;
-		final double vI = (10 * IRON_VALUE * iron) / 28.0;
-		final double vS = (10 * STEEL_VALUE * steel) / 28.0;
-		final double vM = (10 * MITHRIL_VALUE * mithril) / 28.0;
-		final double vA = (10 * ADAMANT_VALUE * adamant) / 28.0;
-		final double vR = (10 * RUNE_VALUE * rune) / 28.0;
+
+		final int bronzeNum = client.getVarbitValue(VARBIT_BRONZE_COUNT);
+		final int ironNum = client.getVarbitValue(VARBIT_IRON_COUNT);
+		final int steelNum = client.getVarbitValue(VARBIT_STEEL_COUNT);
+		final int mithrilNum = client.getVarbitValue(VARBIT_MITHRIL_COUNT);
+		final int adamantNum = client.getVarbitValue(VARBIT_ADAMANT_COUNT);
+		final int runeNum = client.getVarbitValue(VARBIT_RUNE_COUNT);
+
+		final double bronzeVal = (10 * BRONZE_VALUE * bronzeNum) / 28.0;
+		final double ironVal = (10 * IRON_VALUE * ironNum) / 28.0;
+		final double steelVal = (10 * STEEL_VALUE * steelNum) / 28.0;
+		final double mithrilVal = (10 * MITHRIL_VALUE * mithrilNum) / 28.0;
+		final double adamantVal = (10 * ADAMANT_VALUE * adamantNum) / 28.0;
+		final double runeVal = (10 * RUNE_VALUE * runeNum) / 28.0;
+
+		Double[] metals = new Double[] {
+			bronzeVal,
+			ironVal,
+			steelVal,
+			mithrilVal,
+			adamantVal,
+			runeVal
+		};
+
+		// Descending order
+		Arrays.sort(metals, Collections.reverseOrder());
 
 		return
-			(10 * (vB + vI + vS + vM + vA + vR)
-				+ (max1(vB) * max1(vI) * max1(vS) * max1(vM) * max1(vA) * max1(vR))) / 10.0;
+			((10 * metals[0] + 10 * metals[1]) + max1(metals[0]) * max1(metals[1])) / 10.0;
 	}
 
 	/**

--- a/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
@@ -119,7 +119,11 @@ public class FoundryOverlay3D extends Overlay
 			if (config.highlightCrucible())
 			{
 				drawCrucibleIfMouldSet(graphics);
+				drawMouldScoreIfMouldSet(graphics);
 			}
+
+			drawPreformScoreIfPoured(graphics);
+
 			return null;
 		}
 
@@ -269,7 +273,7 @@ public class FoundryOverlay3D extends Overlay
 		{
 			return;
 		}
-		String text = String.format("%d/%d metal score: %d", state.getCrucibleCount(), CRUCIBLE_CAPACITY, (int)state.getCrucibleQuality());
+		String text = String.format("%d/%d score: %d", state.getCrucibleCount(), CRUCIBLE_CAPACITY, (int)state.getCrucibleScore());
 
 		LocalPoint crucibleLoc = crucible.getLocalLocation();
 		crucibleLoc = new LocalPoint(crucibleLoc.getX() - 100, crucibleLoc.getY());
@@ -287,6 +291,48 @@ public class FoundryOverlay3D extends Overlay
 		OverlayUtil.renderTextLocation(graphics, pos, text, color);
 	}
 
+	private void drawMouldScoreIfMouldSet(Graphics2D graphics) {
+		if (client.getVarbitValue(SWORD_TYPE_1_VARBIT) == 0)
+		{
+			return;
+		}
+		if (client.getVarbitValue(VARBIT_GAME_STAGE) != 1)
+		{
+			return;
+		}
+
+		if (state.getMouldScore() == null)
+		{
+			return;
+		}
+
+		String text = String.format("score: %d", state.getMouldScore());
+		LocalPoint mouldLoc = mouldJig.getLocalLocation();
+		Point pos = Perspective.getCanvasTextLocation(client, graphics, mouldLoc, text, 115);
+		Color color = config.generalHighlight();
+
+		OverlayUtil.renderTextLocation(graphics, pos, text, color);
+	}
+	private void drawPreformScoreIfPoured(Graphics2D graphics) {
+		if (client.getVarbitValue(VARBIT_GAME_STAGE) != 2)
+		{
+			return;
+		}
+
+		if (state.getMouldScore() == null || state.getLastKnownCrucibleScore() == null)
+		{
+			return;
+		}
+
+		int preformScore = state.getLastKnownCrucibleScore() + state.getMouldScore();
+		String text = String.format("score: %d", preformScore);
+		LocalPoint mouldLoc = mouldJig.getLocalLocation();
+		Point pos = Perspective.getCanvasTextLocation(client, graphics, mouldLoc, text, 115);
+
+		Color color = config.generalHighlight();
+
+		OverlayUtil.renderTextLocation(graphics, pos, text, color);
+	}
 
 	private void drawCrucibleIfMouldSet(Graphics2D graphics)
 	{

--- a/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
@@ -119,10 +119,13 @@ public class FoundryOverlay3D extends Overlay
 			if (config.highlightCrucible())
 			{
 				drawCrucibleIfMouldSet(graphics);
+			}
+			if (config.drawMouldInfoOverlay())
+			{
 				drawMouldScoreIfMouldSet(graphics);
+				drawPreformScoreIfPoured(graphics);
 			}
 
-			drawPreformScoreIfPoured(graphics);
 
 			return null;
 		}

--- a/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
@@ -269,7 +269,7 @@ public class FoundryOverlay3D extends Overlay
 		{
 			return;
 		}
-		String text = String.format("%d/%d quality: %d", state.getCrucibleCount(), CRUCIBLE_CAPACITY, (int)state.getCrucibleQuality());
+		String text = String.format("%d/%d metal score: %d", state.getCrucibleCount(), CRUCIBLE_CAPACITY, (int)state.getCrucibleQuality());
 
 		LocalPoint crucibleLoc = crucible.getLocalLocation();
 		crucibleLoc = new LocalPoint(crucibleLoc.getX() - 100, crucibleLoc.getY());

--- a/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
@@ -134,7 +134,7 @@ public class FoundryOverlay3D extends Overlay
 			return null;
 		}
 
-		drawHeatingActionOverlay(graphics, stageObject);
+		drawActionOverlay(graphics, stageObject);
 
 		Heat heat = state.getCurrentHeat();
 		Color color = getObjectColor(stage, heat);
@@ -155,11 +155,11 @@ public class FoundryOverlay3D extends Overlay
 
 		if (state.heatingCoolingState.isCooling())
 		{
-			drawHeatingActionOverlay(graphics, waterfall, false);
+			drawHeatingCoolingOverlay(graphics, waterfall);
 		}
 		if (state.heatingCoolingState.isHeating())
 		{
-			drawHeatingActionOverlay(graphics, lavaPool, true);
+			drawHeatingCoolingOverlay(graphics, lavaPool);
 		}
 
 
@@ -192,10 +192,10 @@ public class FoundryOverlay3D extends Overlay
 		modelOutlineRenderer.drawOutline(stageObject, config.borderThickness(), _color, config.borderFeather());
 	}
 
-	private void drawHeatingActionOverlay(
+	private void drawHeatingCoolingOverlay(
 		Graphics2D graphics,
-		GameObject stageObject,
-		boolean isLava /* and not cooling */)
+		GameObject stageObject
+	)
 	{
 		if (!config.drawLavaWaterInfoOverlay())
 		{
@@ -208,22 +208,10 @@ public class FoundryOverlay3D extends Overlay
 		}
 
 		String text;
-		if (isLava)
-		{
-			// %d heats or %d dunks
-			text = String.format("%d %s",
-				state.heatingCoolingState.getRemainingDuration(),
-				state.heatingCoolingState.getActionName()
-			);
-		}
-		else
-		{
-			// %d cools
-			text = String.format("%d %s",
-				state.heatingCoolingState.getRemainingDuration(),
-				state.heatingCoolingState.getActionName()
-			);
-		}
+		text = String.format("%d %s",
+			state.heatingCoolingState.getRemainingDuration(),
+			state.heatingCoolingState.getActionName()
+		);
 
 		LocalPoint stageLoc = stageObject.getLocalLocation();
 		stageLoc = new LocalPoint(stageLoc.getX(), stageLoc.getY());
@@ -437,7 +425,7 @@ public class FoundryOverlay3D extends Overlay
 		}
 	}
 
-	private void drawHeatingActionOverlay(Graphics2D graphics, GameObject gameObject)
+	private void drawActionOverlay(Graphics2D graphics, GameObject gameObject)
 	{
 		int actionsLeft = state.getActionsLeftInStage();
 		int heatLeft = state.getActionsForHeatLevel();

--- a/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
@@ -292,7 +292,7 @@ public class FoundryOverlay3D extends Overlay
 			return;
 		}
 
-		if (state.getMouldScore() == null)
+		if (state.getMouldScore() < 0)
 		{
 			return;
 		}
@@ -310,7 +310,7 @@ public class FoundryOverlay3D extends Overlay
 			return;
 		}
 
-		if (state.getMouldScore() == null || state.getLastKnownCrucibleScore() == null)
+		if (state.getMouldScore() < 0 || state.getLastKnownCrucibleScore() < 0)
 		{
 			return;
 		}

--- a/src/main/java/com/toofifty/easygiantsfoundry/HeatActionSolver.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/HeatActionSolver.java
@@ -78,6 +78,13 @@ public class HeatActionSolver
 {
 
 	/**
+	 * <b>Warning:</b> this method prefers overshooting goal. For example, if goal is 957,
+	 * it will return index that reaches >957.<br>
+	 * This may be desirable if we're aiming to heat over range minimum,
+	 * but undesirable when cooling below range maximum; make sure to -1 the index if so.
+	 *
+	 *
+	 *
 	 * @param goal       the desired heat destination
 	 * @param init_dx1   initial speed of heating/cooling. currently 7 for heat/cool, 27 for dunk/quench.
 	 * @param dx2_offset bonus acceleration. currently, 0 for heat/cool, 2 for dunk/quench.

--- a/src/main/java/com/toofifty/easygiantsfoundry/MouldHelper.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/MouldHelper.java
@@ -23,6 +23,9 @@ public class MouldHelper
 	static final int SWORD_TYPE_2_VARBIT = 13908; // 3=Flat
 	private static final int DISABLED_TEXT_COLOR = 0x9f9f9f;
 
+	private static final int SCORE_TYPE1_SCORE_WIDGET = 47054876;
+	private static final int SCORE_TYPE2_SCORE_WIDGET = 47054878;
+
 	@Inject
 	private Client client;
 
@@ -32,6 +35,47 @@ public class MouldHelper
 	@Inject
 	private EasyGiantsFoundryConfig config;
 
+	public Integer getTotalScore()
+	{
+		Widget type1Widget = client.getWidget(SCORE_TYPE1_SCORE_WIDGET);
+		Widget type2Widget = client.getWidget(SCORE_TYPE2_SCORE_WIDGET);
+		if (type1Widget == null || type2Widget == null)
+		{
+			return null;
+		}
+
+		String type1Str = type1Widget.getText();
+		String type2Str = type2Widget.getText();
+
+		// (+6) 6
+		//     ^ space seperated
+		// or
+		// 6
+		if (type1Str.contains(" "))
+		{
+			type1Str = type1Str.substring(type1Str.lastIndexOf(' ') + 1);
+		}
+
+		if (type2Str.contains(" "))
+		{
+			type2Str = type2Str.substring(type2Str.lastIndexOf(' ') + 1);
+		}
+
+
+		int type1Score;
+		int type2Score;
+
+		try
+		{
+			type1Score = Integer.parseInt(type1Str);
+			type2Score = Integer.parseInt(type2Str);
+		} catch (NumberFormatException e)
+		{
+			return null;
+		}
+
+		return type1Score + type2Score;
+	}
 	public void selectBest(int scriptId)
 	{
 		Widget parent = client.getWidget(MOULD_LIST_PARENT);

--- a/src/test/java/com/toofifty/easygiantsfoundry/HeatSolverTest.java
+++ b/src/test/java/com/toofifty/easygiantsfoundry/HeatSolverTest.java
@@ -90,7 +90,7 @@ public class HeatSolverTest
 
 		for (int i = 0; i < answer_dx1.length; i++)
 		{
-			TestHeatSolver_Dx0_Helper(answer_dx0.get(i), answer_dx0.get(0), i + 1);
+			TestHeatSolver_Dx0_Helper(answer_dx0.get(i), answer_dx0.get(0), i);
 		}
 	}
 
@@ -131,7 +131,9 @@ public class HeatSolverTest
 //		System.err.println(
 //			HeatSolver.findDx0IndexContinue(1000, 7, 0));
 		System.err.println(
-			HeatActionSolver.findDx0Index(1000, 7, 1));
+			HeatActionSolver.findDx0Index(957, 27, 2));
+//		System.err.println(
+//			HeatActionSolver.findDx0Index(1000, 7, 1));
 	}
 
 	public void TestHeatSolver_Dx0_Helper(int dx0, int constant, int answer_index)
@@ -139,7 +141,7 @@ public class HeatSolverTest
 		System.err.print(dx0 + "->" + HeatActionSolver.findDx0Index(dx0, constant, 0) + ",");
 
 		// test calcDx0Index
-		assertEquals("Asserting dx0 index for " + answer_index,
+		assertEquals("Asserting dx0 for index " + answer_index,
 			answer_index, HeatActionSolver.findDx0Index(dx0, constant, 0));
 	}
 


### PR DESCRIPTION
# Heat/Cool Prediction Off-by-1 Bug
Heating and cooling calculations had severe off-by-1 bug, causing players to overshoot or undershoot goal heat. 

# Mould/Preform Score Calculation Overlay

![java_2024-10-29_00-55-46](https://github.com/user-attachments/assets/da11a721-75de-46bb-88ae-6ad545242c6e)

![java_2024-10-29_00-56-08](https://github.com/user-attachments/assets/e4553bfe-e070-4c32-b4b5-e0d58b86d044)

![java_2024-10-29_01-00-24](https://github.com/user-attachments/assets/28d347d0-e401-47ca-bbd6-de75aec4c45c)

# Crucible Score Calculation Bug Fix
![image](https://github.com/user-attachments/assets/18e1b1e3-f777-476e-bfc3-791b73bdab55)

Crucible score only calculates using the top two most abundant metal. This was entirely overlooked in the original implementation.
> In the equation above only the two most abundant metals are used as V_1 and V_2 . Ties prefer the more valuable metal. If a pure metal is used, then that metal is used as V_1 and a value of 0 is used for V_2 .
> https://oldschool.runescape.wiki/w/Giants%27_Foundry#Metal_score