### PR TITLE
text visibility enhancements

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,4 +67,5 @@ Bonus Click Notification |  Information Panel
     * Integrated Smith's outfit effect
 - [Aiadan](https://github.com/Aiadan "Aiadan's github")
   * Added metal counter
-
+- [Rikten X](https://github.com/riktenx "Rikten X's github")
+  * Added configs to enhance text visibility

--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,7 @@ dependencies {
 }
 
 group = 'com.toofifty'
-version = '1.0.10'
+version = '1.0.11'
 
 tasks.withType(JavaCompile).configureEach {
     options.encoding = 'UTF-8'

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryConfig.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryConfig.java
@@ -2,6 +2,8 @@ package com.toofifty.easygiantsfoundry;
 
 import java.awt.Color;
 
+import com.toofifty.easygiantsfoundry.enums.FontType;
+import net.runelite.client.config.Alpha;
 import net.runelite.client.config.Config;
 import net.runelite.client.config.ConfigGroup;
 import net.runelite.client.config.ConfigItem;
@@ -508,6 +510,44 @@ public interface EasyGiantsFoundryConfig extends Config
 	default Color toolBonus()
 	{
 		return Color.CYAN;
+	}
+
+	@ConfigItem(
+		keyName = "textBackground",
+		name = "Text Background",
+		description = "Set a color to draw a box behind text.",
+		position = 7,
+		section = colourList
+	)
+	@Alpha
+	default Color textBackground()
+	{
+		return null;
+	}
+
+	@ConfigItem(
+		keyName = "dynamicOverlayFont",
+		name = "Dynamic Overlay Font",
+		description = "Choose the font type for the info overlay.<br/>" +
+				"Defaults to your setting from RuneLite -> Overlay settings -> Dynamic overlay font.",
+		position = 10,
+		section = colourList
+	)
+	default FontType dynamicOverlayFont()
+	{
+		return FontType.DEFAULT;
+	}
+
+	@ConfigItem(
+		keyName = "textOutline",
+		name = "Text Outline",
+		description = "Use an outline around text instead of a shadow.",
+		position = 11,
+		section = colourList
+	)
+	default boolean textOutline()
+	{
+		return false;
 	}
 
 	@ConfigItem(

--- a/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryHelper.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/EasyGiantsFoundryHelper.java
@@ -1,17 +1,18 @@
 package com.toofifty.easygiantsfoundry;
 
 import lombok.extern.slf4j.Slf4j;
+import net.runelite.api.Point;
 import net.runelite.client.ui.ColorScheme;
 
 import javax.inject.Singleton;
 import java.awt.Color;
+import java.awt.FontMetrics;
+import java.awt.Graphics2D;
 
 @Slf4j
 @Singleton
 public final class EasyGiantsFoundryHelper
 {
-
-
 	public static Color getHeatColor(int actions, int heat)
 	{
 		if (heat >= actions)
@@ -25,5 +26,31 @@ public final class EasyGiantsFoundryHelper
 		}
 
 		return ColorScheme.PROGRESS_ERROR_COLOR;
+	}
+
+	public static void renderTextLocation(Graphics2D graphics, Point point, String text, Color fg, Color bg, boolean outline)
+	{
+		if (bg != null)
+		{
+			FontMetrics fm = graphics.getFontMetrics();
+			graphics.setColor(bg);
+			graphics.fillRect(point.getX(), point.getY() - fm.getHeight(), fm.stringWidth(text), fm.getHeight());
+		}
+
+		graphics.setColor(Color.BLACK);
+		if (outline)
+		{
+			graphics.drawString(text, point.getX(), point.getY() + 1);
+			graphics.drawString(text, point.getX(), point.getY() - 1);
+			graphics.drawString(text, point.getX() + 1, point.getY());
+			graphics.drawString(text, point.getX() - 1, point.getY());
+		}
+		else
+		{
+			graphics.drawString(text, point.getX() + 1, point.getY() + 1);
+		}
+
+		graphics.setColor(fg);
+		graphics.drawString(text, point.getX(), point.getY());
 	}
 }

--- a/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/FoundryOverlay3D.java
@@ -2,9 +2,11 @@ package com.toofifty.easygiantsfoundry;
 
 import static com.toofifty.easygiantsfoundry.EasyGiantsFoundryClientIDs.*;
 import static com.toofifty.easygiantsfoundry.EasyGiantsFoundryHelper.getHeatColor;
+import static com.toofifty.easygiantsfoundry.EasyGiantsFoundryHelper.renderTextLocation;
 import static com.toofifty.easygiantsfoundry.MouldHelper.SWORD_TYPE_1_VARBIT;
 import static com.toofifty.easygiantsfoundry.MouldHelper.SWORD_TYPE_2_VARBIT;
 import com.toofifty.easygiantsfoundry.enums.CommissionType;
+import com.toofifty.easygiantsfoundry.enums.FontType;
 import com.toofifty.easygiantsfoundry.enums.Heat;
 import com.toofifty.easygiantsfoundry.enums.Stage;
 
@@ -24,7 +26,6 @@ import net.runelite.api.coords.LocalPoint;
 import net.runelite.api.widgets.Widget;
 import net.runelite.client.ui.overlay.Overlay;
 import net.runelite.client.ui.overlay.OverlayPosition;
-import net.runelite.client.ui.overlay.OverlayUtil;
 import net.runelite.client.ui.overlay.outline.ModelOutlineRenderer;
 import org.apache.commons.lang3.StringUtils;
 
@@ -107,6 +108,11 @@ public class FoundryOverlay3D extends Overlay
 			return null;
 		}
 
+		if (config.dynamicOverlayFont() != FontType.DEFAULT)
+		{
+			graphics.setFont(config.dynamicOverlayFont().getFont());
+		}
+
 		if (config.highlightKovac())
 		{
 			drawKovacIfHandIn(graphics);
@@ -147,8 +153,6 @@ public class FoundryOverlay3D extends Overlay
 			return null;
 		}
 
-		drawActionOverlay(graphics, stageObject);
-
 		Heat heat = state.getCurrentHeat();
 		Color color = getObjectColor(stage, heat);
 		// TODO Config
@@ -185,6 +189,8 @@ public class FoundryOverlay3D extends Overlay
 				}
 			}
 		}
+
+		drawActionOverlay(graphics, stageObject);
 
 		return null;
 	}
@@ -274,7 +280,7 @@ public class FoundryOverlay3D extends Overlay
 
 		Color color = config.lavaWaterfallColour();
 
-		OverlayUtil.renderTextLocation(graphics, pos, text, color);
+		renderTextLocation(graphics, pos, text, color, config.textBackground(), config.textOutline());
 	}
 
 	private void drawHeatChangerOverlay(Graphics2D graphics, GameObject stageObject)
@@ -304,7 +310,7 @@ public class FoundryOverlay3D extends Overlay
 		Point pos = Perspective.getCanvasTextLocation(client, graphics, stageLoc, text, 50);
 		Color color = config.lavaWaterfallColour();
 
-		OverlayUtil.renderTextLocation(graphics, pos, text, color);
+		renderTextLocation(graphics, pos, text, color, config.textBackground(), config.textOutline());
 	}
 
 	private void drawHeatChangers(Graphics2D graphics)
@@ -382,7 +388,7 @@ public class FoundryOverlay3D extends Overlay
 		{
 			color = config.generalHighlight();
 		}
-		OverlayUtil.renderTextLocation(graphics, pos, text, color);
+		renderTextLocation(graphics, pos, text, color, config.textBackground(), config.textOutline());
 	}
 
 	private void drawMouldScoreIfMouldSet(Graphics2D graphics) {
@@ -405,7 +411,7 @@ public class FoundryOverlay3D extends Overlay
 		Point pos = Perspective.getCanvasTextLocation(client, graphics, mouldLoc, text, 115);
 		Color color = config.generalHighlight();
 
-		OverlayUtil.renderTextLocation(graphics, pos, text, color);
+		renderTextLocation(graphics, pos, text, color, config.textBackground(), config.textOutline());
 	}
 	private void drawPreformScoreIfPoured(Graphics2D graphics) {
 		if (client.getVarbitValue(VARBIT_GAME_STAGE) != 2)
@@ -425,7 +431,7 @@ public class FoundryOverlay3D extends Overlay
 
 		Color color = config.generalHighlight();
 
-		OverlayUtil.renderTextLocation(graphics, pos, text, color);
+		renderTextLocation(graphics, pos, text, color, config.textBackground(), config.textOutline());
 	}
 
 	private void drawCrucibleIfMouldSet(Graphics2D graphics)
@@ -438,8 +444,6 @@ public class FoundryOverlay3D extends Overlay
 		{
 			return;
 		}
-
-		drawCrucibleContent(graphics);
 
 		if (config.highlightStyle() == HighlightStyle.HIGHLIGHT_CLICKBOX)
 		{
@@ -473,6 +477,8 @@ public class FoundryOverlay3D extends Overlay
 			}
 			drawObjectOutline(graphics, crucible, color);
 		}
+
+		drawCrucibleContent(graphics);
 	}
 
 	private void drawMouldIfNotSet(Graphics2D graphics)
@@ -510,7 +516,7 @@ public class FoundryOverlay3D extends Overlay
 			textLocation = new LocalPoint(textLocation.getX(), textLocation.getY());
 			Point canvasLocation = Perspective.getCanvasTextLocation(client, graphics, textLocation, text, 100);
 			canvasLocation = new Point(canvasLocation.getX(), canvasLocation.getY() + 10);
-			OverlayUtil.renderTextLocation(graphics, canvasLocation, text, config.generalHighlight());
+			renderTextLocation(graphics, canvasLocation, text, config.generalHighlight(), config.textBackground(), config.textOutline());
 		}
 	}
 
@@ -562,7 +568,7 @@ public class FoundryOverlay3D extends Overlay
 			{
 				return;
 			}
-			OverlayUtil.renderTextLocation(graphics, canvasLocation, text, getHeatColor(actionsLeft, heatLeft));
+			renderTextLocation(graphics, canvasLocation, text, getHeatColor(actionsLeft, heatLeft), config.textBackground(), config.textOutline());
 		}
 		if (config.drawActionLeftOverlay())
 		// Draw actions left
@@ -575,8 +581,8 @@ public class FoundryOverlay3D extends Overlay
 			{
 				return;
 			}
-			canvasLocation = new Point(canvasLocation.getX(), canvasLocation.getY() + 10);
-			OverlayUtil.renderTextLocation(graphics, canvasLocation, text, getHeatColor(actionsLeft, heatLeft));
+			canvasLocation = new Point(canvasLocation.getX(), canvasLocation.getY() + graphics.getFontMetrics().getHeight());
+			renderTextLocation(graphics, canvasLocation, text, getHeatColor(actionsLeft, heatLeft), config.textBackground(), config.textOutline());
 		}
 	}
 }

--- a/src/main/java/com/toofifty/easygiantsfoundry/enums/FontType.java
+++ b/src/main/java/com/toofifty/easygiantsfoundry/enums/FontType.java
@@ -1,0 +1,27 @@
+package com.toofifty.easygiantsfoundry.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import net.runelite.client.ui.FontManager;
+
+import java.awt.Font;
+
+@Getter
+@AllArgsConstructor
+public enum FontType
+{
+	DEFAULT("Default", null),
+	REGULAR("Regular", FontManager.getRunescapeFont()),
+	BOLD("Bold", FontManager.getRunescapeBoldFont()),
+	SMALL("Small", FontManager.getRunescapeSmallFont()),
+	;
+
+	private final String name;
+	private final Font font;
+
+	@Override
+	public String toString()
+	{
+		return name;
+	}
+}


### PR DESCRIPTION
Closes #36

Changes:
* the prediction text was rendered _under_ the object overlay, making it harder to see, this fixes that
* adds an option to draw that text with an outline, rather than a shadow, which improves visibility of the text more (at least for some, definitely for me)
* adds option to override RuneLite's dynamic overlay font
* spaces action/heat text according to font height (normal/bold made the text crammed together)
* adds option to draw a semi-transparent black backdrop under the text